### PR TITLE
forcing openms version higher than 2.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - click
   - sdrf-pipelines>=0.0.31
-  - pyopenms>=2.4.0
+  - pyopenms>=3.0.0
   - pandas
   - numpy
   - pyarrow

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - click
   - sdrf-pipelines>=0.0.31
-  - pyopenms>=3.0.0
+  - pyopenms>=2.4.0
   - pandas
   - numpy
   - pyarrow

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - click
   - sdrf-pipelines>=0.0.31
-  - pyopenms
+  - pyopenms>=2.4.0
   - pandas
   - numpy
   - pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 python = ">=3.8,<3.11"
 click = "*"
 sdrf-pipelines = ">=0.0.31"
-pyopenms = "*"
+pyopenms = ">=2.4.0"
 ms2rescore = "3.0.3"
 pandas = "*"
 numpy = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 python = ">=3.8,<3.11"
 click = "*"
 sdrf-pipelines = ">=0.0.31"
-pyopenms = ">=3.0.0"
+pyopenms = ">=2.4.0"
 ms2rescore = "3.0.3"
 pandas = "*"
 numpy = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ packages = [
 python = ">=3.8,<3.11"
 click = "*"
 sdrf-pipelines = ">=0.0.31"
-pyopenms = ">=2.4.0"
+pyopenms = ">=3.0.0"
 ms2rescore = "3.0.3"
 pandas = "*"
 numpy = "*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python >=3.8,<3.11
     - click
     - sdrf-pipelines>=0.0.31
-    - pyopenms>=3.0.0
+    - pyopenms>=2.4.0
     - pandas
     - numpy
     - pyarrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python >=3.8,<3.11
     - click
     - sdrf-pipelines>=0.0.31
-    - pyopenms>=2.4.0
+    - pyopenms>=3.0.0
     - pandas
     - numpy
     - pyarrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python >=3.8,<3.11
     - click
     - sdrf-pipelines>=0.0.31
-    - pyopenms
+    - pyopenms>=2.4.0
     - pandas
     - numpy
     - pyarrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 sdrf-pipelines>=0.0.31
-pyopenms>=2.4.0
+pyopenms>=3.0.0
 ms2rescore==3.0.3
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 sdrf-pipelines>=0.0.31
-pyopenms>=3.0.0
+pyopenms>=2.4.0
 ms2rescore==3.0.3
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 sdrf-pipelines>=0.0.31
-pyopenms
+pyopenms>=2.4.0
 ms2rescore==3.0.3
 pandas
 numpy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the version requirement for the `pyopenms` dependency to ensure compatibility with version 2.4.0 or higher across multiple configuration files.

- **Chores**
	- Modified `environment.yml`, `pyproject.toml`, `recipe/meta.yaml`, and `requirements.txt` to reflect the new version constraints for `pyopenms`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->