### PR TITLE
fix(diann2msstats): keep raw sequence when pyopenms can't resolve a mod

### DIFF
--- a/quantmsutils/diann/diann2msstats.py
+++ b/quantmsutils/diann/diann2msstats.py
@@ -73,14 +73,8 @@ def diann2msstats(
     out_msstats = out_msstats[out_msstats["Intensity"] != 0]
 
     out_msstats["PeptideSequence"] = out_msstats["PeptideSequence"].apply(_sanitize_sequence)
-    out_msstats.loc[:, "PeptideSequence"] = out_msstats.apply(
-        lambda x: (
-            AASequence.fromString(x["PeptideSequence"]).toString()
-            if "^" not in x["PeptideSequence"]
-            else "^" + AASequence.fromString(x["PeptideSequence"].replace("^", "")).toString()
-        ),
-        axis=1,
-    )
+    seq_map = {s: _to_openms_sequence(s) for s in out_msstats["PeptideSequence"].unique()}
+    out_msstats["PeptideSequence"] = out_msstats["PeptideSequence"].map(seq_map)
     out_msstats["FragmentIon"] = "NA"
     out_msstats["ProductCharge"] = "0"
 
@@ -267,3 +261,31 @@ def load_report(report_path, qvalue_threshold: float) -> pd.DataFrame:
 def _sanitize_sequence(seq):
     seq = seq.replace("(SILAC)", "")
     return seq
+
+
+def _to_openms_sequence(seq: str) -> str:
+    """Canonicalize a DIA-NN peptide+mod string via pyopenms.
+
+    Preserves the leading ``^`` anchor used by DIA-NN to mark N-terminal
+    cleavage peptides. When pyopenms raises a ``RuntimeError`` — typically
+    because the runtime container ships pyopenms without the OpenMS share
+    directory (UniMod XML), leaving only a small set of common modifications
+    resolvable from the compiled-in fallback — the input is returned
+    unchanged so downstream conversion can proceed. A warning is logged
+    once per unique input string.
+    """
+    has_anchor = "^" in seq
+    body = seq.replace("^", "") if has_anchor else seq
+    try:
+        canonical = AASequence.fromString(body).toString()
+    except RuntimeError as err:
+        logger.warning(
+            "pyopenms could not parse peptide %r (%s); keeping the raw "
+            "DIA-NN sequence. If this affects many peptides, the runtime "
+            "container is likely missing the OpenMS share directory "
+            "(OPENMS_DATA_PATH).",
+            body,
+            err,
+        )
+        canonical = body
+    return ("^" + canonical) if has_anchor else canonical

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,6 +103,35 @@ class TestDiannCommands:
 
         assert result.exit_code == 0
 
+    def test_to_openms_sequence_falls_back_on_unknown_mod(self):
+        """Unknown modifications should not crash the conversion.
+
+        The runtime container may ship pyopenms without the OpenMS share
+        directory, leaving only common mods resolvable. In that case we
+        keep the raw DIA-NN sequence so downstream MSstats conversion can
+        proceed instead of crashing with a RuntimeError.
+        """
+        from quantmsutils.diann.diann2msstats import _to_openms_sequence
+
+        bogus = "M(NoSuchModXYZ)PEPTIDE"
+        assert _to_openms_sequence(bogus) == bogus
+
+    def test_to_openms_sequence_preserves_n_term_anchor(self):
+        """The leading ``^`` anchor used by DIA-NN for N-terminal cleavage
+        peptides must survive both the pyopenms round-trip and the
+        fallback path.
+        """
+        from quantmsutils.diann.diann2msstats import _to_openms_sequence
+
+        # known mod -> canonical form retains anchor
+        anchored = "^M(Oxidation)PEPTIDE"
+        out = _to_openms_sequence(anchored)
+        assert out.startswith("^")
+
+        # unknown mod -> raw passthrough retains anchor
+        bogus_anchored = "^M(NoSuchModXYZ)PEPTIDE"
+        assert _to_openms_sequence(bogus_anchored) == bogus_anchored
+
 
 class TestSamplesheetCommands:
     """Test class for samplesheet related commands"""


### PR DESCRIPTION
## Summary

`diann2msstats` crashes the whole conversion when DIA-NN emits a peptide with a modification that pyopenms cannot resolve. This is the bug that surfaces as:

```
RuntimeError: the value 'Met-loss' was used but is not valid;
Cannot convert string to peptide modification.
No modification matches in our database.
```

…always preceded by:

```
UserWarning: OPENMS_DATA_PATH environment variable not found and
no share directory was installed.
```

The runtime container ships pyopenms **without** the OpenMS share directory (UniMod XML), so only a small set of compiled-in common mods (Carbamidomethyl, Oxidation, Phospho, …) resolves. Any DIA-NN run whose SDRF declares Acetyl, Met-loss, Met-loss+Acetyl, or any less-common UniMod entry crashes outright.

This PR makes the converter resilient to that state.

## Changes

- New helper `_to_openms_sequence(seq)` that wraps `AASequence.fromString` in a `try/except RuntimeError`, logs a warning, and returns the input unchanged on failure. The leading `^` anchor used by DIA-NN for N-terminal-cleavage peptides is preserved on both the canonical and fallback paths.
- Dedupe the conversion: build a map over the unique `PeptideSequence` values and re-map back. The old `.apply(..., axis=1)` re-parsed identical strings on every row — wasteful on real (multi-million-row) DIA reports.
- Two unit tests in `TestDiannCommands`:
  - unknown modification falls back to the raw input
  - `^` anchor preserved on both paths

## Why the raw string is safe to pass through

MSstats only needs `PeptideSequence` to be a **stable identifier per peptidoform**. The DIA-NN string is already that — different mod forms produce different strings — so downstream conversion is unaffected. Only the cosmetic "canonical form" is lost for the unresolvable rows.

## Test plan

```bash
pytest tests/test_commands.py::TestDiannCommands -v
```

All three relevant tests pass locally:

```
test_to_openms_sequence_falls_back_on_unknown_mod  PASSED
test_to_openms_sequence_preserves_n_term_anchor    PASSED
test_diann2msstats_example                         PASSED   (regression check)
```

## Related upstream fix needed

The deeper fix is the **bioconda recipe**: `quantms-utils` should ship pyopenms with the OpenMS share directory (or set `OPENMS_DATA_PATH`) so the parser has the full UniMod database. Filing a separate issue against this repo to track the container packaging side; this source PR is the resilient companion that prevents future surprise mods from crashing the converter even after the recipe is fixed.

## Reproduction context

Hit in the wild during a reanalysis of [PXD004701](https://www.ebi.ac.uk/pride/archive/projects/PXD004701) (Sun et al. 2023, MCP) whose SDRF correctly declared `N-term Met-loss` (UniMod:765). Same failure mode previously surfaced with Acetyl (UniMod:1) on other datasets. Repro details in the companion issue.